### PR TITLE
refactor: remove classic engine configuration from Prisma setup

### DIFF
--- a/dashboard/prisma.config.ts
+++ b/dashboard/prisma.config.ts
@@ -11,7 +11,6 @@ export default defineConfig({
   migrations: {
     path: "prisma/migrations",
   },
-  engine: "classic",
   datasource: {
     url: env("DATABASE_URL"),
   },


### PR DESCRIPTION
- Eliminated the "classic" engine configuration from the Prisma configuration file to streamline the setup and align with current best practices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database configuration to use the default Prisma engine setting, streamlining the configuration setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->