### PR TITLE
Fix/job-logs-endpoint-gitignore

### DIFF
--- a/dashboard/app/api/jobs/[id]/job-logs/route.ts
+++ b/dashboard/app/api/jobs/[id]/job-logs/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireProjectId } from '@/lib/project';
+
+const backendUrl = process.env.BACKEND_URL || 'http://localhost:8000';
+
+function backendError(status: number) {
+  return status >= 500 ? 502 : status;
+}
+
+export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const { id } = await params;
+    const projectId = await requireProjectId(request);
+    const { searchParams } = new URL(request.url);
+    const cursor = searchParams.get('cursor') || '0';
+    const limit = searchParams.get('limit') || '200';
+
+    const backendParams = new URLSearchParams();
+    backendParams.set('project_id', projectId);
+    backendParams.set('cursor', cursor);
+    backendParams.set('limit', limit);
+
+    const backendRequestUrl = `${backendUrl}/jobs/${encodeURIComponent(id)}/logs?${backendParams.toString()}`;
+    console.log('[logs] Fetching from backend:', backendRequestUrl);
+
+    const response = await fetch(backendRequestUrl, {
+      signal: AbortSignal.timeout(15000),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      console.error(`[logs] Backend returned ${response.status} for job logs GET`);
+      console.error(`[logs] Backend URL: ${backendRequestUrl}`);
+      console.error(`[logs] Backend response: ${errorText}`);
+      return NextResponse.json({
+        error: 'Failed to fetch job logs',
+        debug: { status: response.status, url: backendRequestUrl, response: errorText }
+      }, { status: backendError(response.status) });
+    }
+    const data = await response.json();
+    return NextResponse.json(data, { status: response.status });
+  } catch (error: any) {
+    if (error?.message === 'project_id is required') {
+      return NextResponse.json({ error: 'project_id is required' }, { status: 400 });
+    }
+    if (error?.name === 'AbortError' || error?.message?.includes('timeout')) {
+      return NextResponse.json({ error: 'Backend request timed out' }, { status: 503 });
+    }
+    console.error('Error fetching job logs:', error);
+    return NextResponse.json({ error: 'Failed to fetch job logs' }, { status: 500 });
+  }
+}
+

--- a/dashboard/app/prs/page.tsx
+++ b/dashboard/app/prs/page.tsx
@@ -51,7 +51,7 @@ export default function PrsPage() {
         let cancelled = false;
         const fetchLogs = async () => {
             try {
-                const res = await fetch(`/api/jobs/${encodeURIComponent(selectedJobId)}/logs?cursor=0&limit=200`);
+                const res = await fetch(`/api/jobs/${encodeURIComponent(selectedJobId)}/job-logs?cursor=0&limit=200`);
                 if (!res.ok) return;
                 const payload = (await res.json()) as JobLogsPayload;
                 if (!cancelled) {


### PR DESCRIPTION
The /api/jobs/[id]/logs endpoint was being ignored by .gitignore (line 2: "logs")
which prevented it from being deployed to production. This caused 404 errors when
trying to fetch job logs in production.

Changes:
- Renamed dashboard/app/api/jobs/[id]/logs/ → job-logs/
- Updated dashboard/app/prs/page.tsx to call /job-logs endpoint
- Added detailed error logging to help debug future issues

Fixes: Production 404 error when fetching job logs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated job logs retrieval endpoint infrastructure with enhanced error handling and timeout management for improved reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->