### PR TITLE
Update project metadata and add Soulcaster favicon

### DIFF
--- a/dashboard/app/layout.tsx
+++ b/dashboard/app/layout.tsx
@@ -15,8 +15,25 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: 'FeedbackAgent Dashboard',
-  description: 'Self-healing dev loop triage dashboard',
+  title: 'Soulcaster',
+  description:
+    'AI-powered feedback triage and automated fix generation. Ingest bug reports, cluster similar issues, and generate PRs automatically.',
+  icons: {
+    icon: '/favicon.svg',
+    apple: '/favicon.svg',
+  },
+  openGraph: {
+    title: 'Soulcaster',
+    description:
+      'AI-powered feedback triage and automated fix generation. Ingest bug reports, cluster similar issues, and generate PRs automatically.',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary',
+    title: 'Soulcaster',
+    description:
+      'AI-powered feedback triage and automated fix generation. Ingest bug reports, cluster similar issues, and generate PRs automatically.',
+  },
 };
 
 /**

--- a/dashboard/public/favicon.svg
+++ b/dashboard/public/favicon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#34d399"/>
+      <stop offset="100%" style="stop-color:#059669"/>
+    </linearGradient>
+  </defs>
+  <circle cx="16" cy="16" r="16" fill="url(#bg)"/>
+  <path d="M17.33 5.33L8 18.67h6l-.67 8L22 13.33h-6l1.33-8z" fill="#000"/>
+</svg>


### PR DESCRIPTION
## Summary
- Updated browser tab title from "FeedbackAgent Dashboard" to "Soulcaster"
- Added descriptive meta description for better SEO
- Added OpenGraph and Twitter card metadata for rich social previews (WhatsApp, Slack, etc.)
- Added Soulcaster favicon (lightning bolt logo in emerald green circle)

## Test plan
- [x] Verify browser tab shows "Soulcaster" title
- [x] Check favicon appears in browser tab
- [x] Test social preview by sharing link (e.g., WhatsApp, Slack)

Fixes https://github.com/altock/soulcaster/issues/101

🤖 Generated with [Claude Code](https://claude.com/claude-code)