### PR TITLE
fix: use lazy state initialization instead of useEffect for portal root

### DIFF
--- a/dashboard/components/integrations/RequestIntegrationDialog.tsx
+++ b/dashboard/components/integrations/RequestIntegrationDialog.tsx
@@ -62,12 +62,10 @@ export default function RequestIntegrationDialog({
   const [name, setName] = useState(defaultName);
   const [details, setDetails] = useState('');
   const [copyState, setCopyState] = useState<'idle' | 'copied' | 'failed'>('idle');
-  const [portalRoot, setPortalRoot] = useState<HTMLElement | null>(null);
+  const [portalRoot] = useState<HTMLElement | null>(() =>
+    typeof document !== 'undefined' ? document.body : null
+  );
   const nameInputRef = useRef<HTMLInputElement | null>(null);
-
-  useEffect(() => {
-    setPortalRoot(document.body);
-  }, []);
 
   const requestBody = useMemo(() => {
     const lines = [


### PR DESCRIPTION
Replace useEffect + setState pattern with lazy state initialization to avoid unnecessary re-render and fix react-hooks/set-state-in-effect ESLint error.